### PR TITLE
feat: trim empty month rows in weekdays-only view

### DIFF
--- a/lib/src/table_calendar.dart
+++ b/lib/src/table_calendar.dart
@@ -113,6 +113,13 @@ class TableCalendar<T> extends StatefulWidget {
   /// Wether to display only weekdays, will exclude all days in [weekendDays].
   final bool onlyWeekdays;
 
+  /// When enabled (and `onlyWeekdays` is true), calendar will not render
+  /// leading/trailing month rows that contain no days from the focused month.
+  ///
+  /// This is useful with `onlyWeekdays: true` + `calendarStyle.outsideDaysVisible: false`
+  /// to avoid completely empty first/last rows when the month starts/ends on weekend.
+  final bool trimEmptyWeekRows;
+
   /// Used for setting the height of `TableCalendar`'s rows.
   final double rowHeight;
 
@@ -237,6 +244,7 @@ class TableCalendar<T> extends StatefulWidget {
     this.shouldFillViewport = false,
     this.weekNumbersVisible = false,
     this.onlyWeekdays = false,
+    bool? trimEmptyWeekRows,
     this.rowHeight = 52.0,
     this.daysOfWeekHeight = 16.0,
     this.formatAnimationDuration = const Duration(milliseconds: 200),
@@ -281,7 +289,12 @@ class TableCalendar<T> extends StatefulWidget {
         focusedDay = normalizeDate(focusedDay),
         firstDay = normalizeDate(firstDay),
         lastDay = normalizeDate(lastDay),
-        currentDay = currentDay ?? DateTime.now();
+        currentDay = currentDay ?? DateTime.now(),
+        trimEmptyWeekRows = trimEmptyWeekRows ??
+            (onlyWeekdays &&
+                calendarFormat == CalendarFormat.month &&
+                !sixWeekMonthsEnforced &&
+                !calendarStyle.outsideDaysVisible);
 
   @override
   State<TableCalendar<T>> createState() => _TableCalendarState<T>();
@@ -518,6 +531,7 @@ class _TableCalendarState<T> extends State<TableCalendar<T>> {
             onVerticalSwipe: _swipeCalendarFormat,
             onlyWeekdays: widget.onlyWeekdays,
             weekendDays: widget.weekendDays,
+            trimEmptyWeekRows: widget.trimEmptyWeekRows,
             onPageChanged: (focusedDay) {
               _focusedDay.value = focusedDay;
               widget.onPageChanged?.call(focusedDay);

--- a/lib/src/table_calendar_base.dart
+++ b/lib/src/table_calendar_base.dart
@@ -44,6 +44,7 @@ class TableCalendarBase extends StatefulWidget {
   final void Function(PageController pageController)? onCalendarCreated;
   final bool onlyWeekdays;
   final List<int> weekendDays;
+  final bool trimEmptyWeekRows;
 
   TableCalendarBase({
     super.key,
@@ -77,6 +78,7 @@ class TableCalendarBase extends StatefulWidget {
     this.availableCalendarFormats = kDefaultAvailableCalendarFormats,
     this.onlyWeekdays = false,
     this.weekendDays = kDefaultWeekendDays,
+    this.trimEmptyWeekRows = false,
     this.onVerticalSwipe,
     this.onPageChanged,
     this.onCalendarCreated,
@@ -132,7 +134,10 @@ class _TableCalendarBaseState extends State<TableCalendarBase> {
     if (widget.rowHeight != oldWidget.rowHeight ||
         widget.dowHeight != oldWidget.dowHeight ||
         widget.dowVisible != oldWidget.dowVisible ||
-        widget.sixWeekMonthsEnforced != oldWidget.sixWeekMonthsEnforced) {
+        widget.sixWeekMonthsEnforced != oldWidget.sixWeekMonthsEnforced ||
+        widget.trimEmptyWeekRows != oldWidget.trimEmptyWeekRows ||
+        widget.onlyWeekdays != oldWidget.onlyWeekdays ||
+        widget.weekendDays != oldWidget.weekendDays) {
       final rowCount = _getRowCount(widget.calendarFormat, _focusedDay);
       _pageHeight.value = _getPageHeight(rowCount);
     }
@@ -241,6 +246,7 @@ class _TableCalendarBaseState extends State<TableCalendarBase> {
               rowDecoration: widget.rowDecoration,
               tableBorder: widget.tableBorder,
               tablePadding: widget.tablePadding,
+              trimEmptyWeekRows: widget.trimEmptyWeekRows,
               onPageChanged: (index, focusedMonth) {
                 if (!_pageCallbackDisabled) {
                   if (!isSameDay(_focusedDay, focusedMonth)) {
@@ -326,6 +332,30 @@ class _TableCalendarBaseState extends State<TableCalendarBase> {
     final last = _lastDayOfMonth(focusedDay);
     final daysAfter = _getDaysAfter(last);
     final lastToDisplay = last.add(Duration(days: daysAfter));
+
+    if (widget.trimEmptyWeekRows && widget.onlyWeekdays) {
+      final dayCount = lastToDisplay.difference(firstToDisplay).inDays + 1;
+      final allDays = List.generate(
+        dayCount,
+        (index) =>
+            DateTime.utc(firstToDisplay.year, firstToDisplay.month, firstToDisplay.day + index),
+      )..removeWhere((d) => widget.weekendDays.contains(d.weekday));
+
+      final daysInWeek = DateTime.daysPerWeek - widget.weekendDays.length;
+      if (allDays.isEmpty || allDays.length % daysInWeek != 0) {
+        return (lastToDisplay.difference(firstToDisplay).inDays + 1) ~/ 7;
+      }
+
+      int rows = 0;
+      for (int i = 0; i < allDays.length; i += daysInWeek) {
+        final week = allDays.sublist(i, i + daysInWeek);
+        final hasInMonth = week.any(
+          (d) => d.year == focusedDay.year && d.month == focusedDay.month,
+        );
+        if (hasInMonth) rows++;
+      }
+      return rows == 0 ? 1 : rows;
+    }
 
     return (lastToDisplay.difference(firstToDisplay).inDays + 1) ~/ 7;
   }

--- a/lib/src/widgets/calendar_core.dart
+++ b/lib/src/widgets/calendar_core.dart
@@ -3,8 +3,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:table_calendar/src/shared/utils.dart';
+import 'package:table_calendar/src/table_calendar_base.dart';
 import 'package:table_calendar/src/widgets/calendar_page.dart';
-import 'package:table_calendar/table_calendar.dart';
 
 class CalendarCore extends StatelessWidget {
   final DateTime? focusedDay;
@@ -31,6 +31,7 @@ class CalendarCore extends StatelessWidget {
   final void Function(int, DateTime) onPageChanged;
   final bool onlyWeekdays;
   final List<int> weekendDays;
+  final bool trimEmptyWeekRows;
 
   const CalendarCore({
     super.key,
@@ -58,7 +59,44 @@ class CalendarCore extends StatelessWidget {
     this.scrollPhysics,
     this.onlyWeekdays = false,
     this.weekendDays = kDefaultWeekendDays,
+    this.trimEmptyWeekRows = false,
   }) : assert(!dowVisible || (dowHeight != null && dowBuilder != null));
+
+  List<DateTime> _trimOutsideMonthWeeks({
+    required List<DateTime> days,
+    required DateTime focusedMonth,
+    required int daysInWeek,
+  }) {
+    if (days.isEmpty) return days;
+    if (days.length % daysInWeek != 0) return days;
+
+    final weeks = <List<DateTime>>[];
+    for (int i = 0; i < days.length; i += daysInWeek) {
+      weeks.add(days.sublist(i, i + daysInWeek));
+    }
+
+    bool hasInMonthDay(List<DateTime> week) =>
+        week.any((d) => d.month == focusedMonth.month && d.year == focusedMonth.year);
+
+    int start = 0;
+    while (start < weeks.length && !hasInMonthDay(weeks[start])) {
+      start++;
+    }
+
+    int end = weeks.length - 1;
+    while (end >= start && !hasInMonthDay(weeks[end])) {
+      end--;
+    }
+
+    if (start == 0 && end == weeks.length - 1) {
+      return days;
+    }
+    if (start > end) {
+      return const <DateTime>[];
+    }
+
+    return weeks.sublist(start, end + 1).expand((w) => w).toList(growable: false);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -69,9 +107,23 @@ class CalendarCore extends StatelessWidget {
       itemBuilder: (context, index) {
         final baseDay = _getBaseDay(calendarFormat, index);
         final visibleRange = _getVisibleRange(calendarFormat, baseDay);
-        final visibleDays = !onlyWeekdays
+        var visibleDays = !onlyWeekdays
             ? _daysInRange(visibleRange.start, visibleRange.end)
             : _weekDaysInRange(visibleRange.start, visibleRange.end);
+        final daysInWeek = !onlyWeekdays
+            ? DateTime.daysPerWeek
+            : DateTime.daysPerWeek - weekendDays.length;
+
+        if (trimEmptyWeekRows &&
+            calendarFormat == CalendarFormat.month &&
+            onlyWeekdays &&
+            !sixWeekMonthsEnforced) {
+          visibleDays = _trimOutsideMonthWeeks(
+            days: visibleDays,
+            focusedMonth: baseDay,
+            daysInWeek: daysInWeek,
+          );
+        }
 
         final actualDowHeight = dowVisible ? dowHeight! : 0.0;
         final constrainedRowHeight = constraints.hasBoundedHeight
@@ -86,9 +138,7 @@ class CalendarCore extends StatelessWidget {
           rowDecoration: rowDecoration,
           tableBorder: tableBorder,
           tablePadding: tablePadding,
-          daysInWeek: !onlyWeekdays
-              ? DateTime.daysPerWeek
-              : DateTime.daysPerWeek - weekendDays.length,
+          daysInWeek: daysInWeek,
           dowBuilder: (context, day) {
             return SizedBox(
               height: dowHeight,


### PR DESCRIPTION
Avoid rendering leading/trailing month rows that contain no in-month weekdays when outside days are hidden.

onlyWeekdays: true + outsideDaysVisible: false iken ay hafta sonu ile başlarsa ilk satır tamamen boş kalıyordu.
Bu PR, ay görünümünde ay içi hafta içi gün hiç yoksa (leading/trailing) o hafta satırını render etmiyor.
Varsayılan olarak sadece bu kombinasyonda devreye girer; diğer senaryoları etkilemez.